### PR TITLE
Optional auth expiration override

### DIFF
--- a/src/SeoMoz/SeoMoz.php
+++ b/src/SeoMoz/SeoMoz.php
@@ -23,11 +23,15 @@ class SeoMoz
 
     /**
      * @param string $domainName Domain name to get SeoMoz data for
+     * @param mixed $expires The expiration time of the SeoMoz auth (defaults to +5m)
      * @return string SeoMoz-url
      */
-    public function getSeoMozUrl($domainName)
+    public function getSeoMozUrl($domainName, $expires=null)
     {
-        $expires = time() + 300;
+        if(is_null($expires)) {
+            $expires = time() + 300;
+        }
+        
         $stringToSign = $this->accessId."\n".$expires;
 
         $binarySignature = hash_hmac('sha1', $stringToSign, $this->secretKey, true);


### PR DESCRIPTION
Add an optional expires parameter to the getSeoMozUrl method to allow for auth expiration adjustments
